### PR TITLE
Use standard `wheel` event instead of non-standard `mousewheel` event

### DIFF
--- a/Source/scripts/guardian.ruins.js
+++ b/Source/scripts/guardian.ruins.js
@@ -129,7 +129,7 @@ my.getRuin = function (setOptions) {
 		this._prepSVG = function(){
 			var registerTouch = 0;
 			//Mouse wheel zoom
-			panZoomComp.parent().on('mousewheel.focal', function( e ) {
+			panZoomComp.parent().on('wheel.focal', function( e ) {
 				e.preventDefault();
 				var delta = e.delta || e.originalEvent.wheelDelta;
 				var zoomOut = delta ? delta < 0 : e.originalEvent.deltaY > 0;


### PR DESCRIPTION
Firefox doesn't support the non-standard `mousewheel` event so the ruins
maps can not be zoomed with the mouse wheel in this browser.  Using the
standard `wheel` event instead fixes this.